### PR TITLE
Added server adding page

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -2,12 +2,10 @@
   "ip": "127.0.0.1",
   "port": 4567,
   "storagePath": "/var/lib/serverstatus/",
-  "credentials": [
-    {
+  "primaryCredentials": {
       "jid": "dummy@example.com",
       "password": "secret"
-    }
-  ],
+  },
   "additionalDomains": [
     "jabber.org"
   ]

--- a/config.example.json
+++ b/config.example.json
@@ -2,10 +2,7 @@
   "ip": "127.0.0.1",
   "port": 4567,
   "storagePath": "/var/lib/serverstatus/",
-  "primaryCredentials": {
-      "jid": "dummy@example.com",
-      "password": "secret"
-  },
+  "primaryDomain" : "domain.com",
   "additionalDomains": [
     "jabber.org"
   ]

--- a/src/main/java/im/conversations/status/Main.java
+++ b/src/main/java/im/conversations/status/Main.java
@@ -36,14 +36,8 @@ public class Main {
     }
 
     private static void main(Options options) {
-        try {
-            if (Configuration.getInstance().getPrimaryCredentials() == null) {
-                System.err.println("Database does not contain primary credentials.");
-                return;
-            }
-        } catch (RuntimeException e) {
-            System.err.println(e.getMessage());
-            return;
+        if (Configuration.getInstance().getPrimaryDomain() == null) {
+            System.err.println("Configuration does not have primary domain");
         }
 
         ipAddress(Configuration.getInstance().getIp());

--- a/src/main/java/im/conversations/status/Main.java
+++ b/src/main/java/im/conversations/status/Main.java
@@ -37,8 +37,9 @@ public class Main {
 
     private static void main(Options options) {
         try {
-            if (CredentialStore.INSTANCE.getCredentialsList().size() == 0) {
-                System.out.println("Database doesnot contain credentials.");
+            if (Configuration.getInstance().getPrimaryCredentials() == null) {
+                System.err.println("Database does not contain primary credentials.");
+                return;
             }
         } catch (RuntimeException e) {
             System.err.println(e.getMessage());

--- a/src/main/java/im/conversations/status/Main.java
+++ b/src/main/java/im/conversations/status/Main.java
@@ -36,6 +36,8 @@ public class Main {
     }
 
     private static void main(Options options) {
+
+
         if (Configuration.getInstance().getPrimaryDomain() == null) {
             System.err.println("Configuration does not have primary domain");
         }
@@ -53,6 +55,8 @@ public class Main {
         get("/historical/", Controller.getHistorical, templateEngine);
         post("/add/",Controller.postAdd, templateEngine);
         get("/add/", Controller.getAdd, templateEngine);
+        get("/live/:domain/",Controller.getLive,templateEngine);
+        get("/availability/:domain/", Controller.getAvailability);
         get("/reverse/:domain/", Controller.getReverse, templateEngine);
         get("/:domain/", Controller.getStatus, templateEngine);
         scheduleStatusCheck();

--- a/src/main/java/im/conversations/status/Main.java
+++ b/src/main/java/im/conversations/status/Main.java
@@ -1,14 +1,17 @@
 package im.conversations.status;
 
+import im.conversations.status.persistence.CredentialStore;
 import im.conversations.status.persistence.ServerStatusStore;
 import im.conversations.status.pojo.Configuration;
 import im.conversations.status.pojo.Credentials;
 import im.conversations.status.web.Controller;
 import im.conversations.status.xmpp.ServerStatusChecker;
 import org.apache.commons.cli.*;
+import rocks.xmpp.addr.Jid;
 import spark.TemplateEngine;
 import spark.template.freemarker.FreeMarkerEngine;
 
+import java.util.List;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -16,6 +19,7 @@ import static spark.Spark.*;
 
 public class Main {
 
+    private static ScheduledThreadPoolExecutor scheduledThreadPoolExecutor = new ScheduledThreadPoolExecutor(5);
     public static void main(String... args) {
         Options options = new Options();
         options.addOption(new Option("c","config",true,"Path to the config file"));
@@ -33,9 +37,8 @@ public class Main {
 
     private static void main(Options options) {
         try {
-            if (Configuration.getInstance().getCredentials().size() == 0) {
-                System.err.println("Please specify at least one login credentials");
-                return;
+            if (CredentialStore.INSTANCE.getCredentialsList().size() == 0) {
+                System.out.println("Database doesnot contain credentials.");
             }
         } catch (RuntimeException e) {
             System.err.println(e.getMessage());
@@ -53,11 +56,19 @@ public class Main {
 
         get("/", Controller.getStatus, templateEngine);
         get("/historical/", Controller.getHistorical, templateEngine);
+        post("/add/",Controller.postAdd, templateEngine);
+        get("/add/", Controller.getAdd, templateEngine);
         get("/reverse/:domain/", Controller.getReverse, templateEngine);
         get("/:domain/", Controller.getStatus, templateEngine);
-        ScheduledThreadPoolExecutor scheduledThreadPoolExecutor = new ScheduledThreadPoolExecutor(5);
-        for (Credentials credentials : Configuration.getInstance().getCredentials()) {
-            scheduledThreadPoolExecutor.scheduleAtFixedRate(new ServerStatusChecker(credentials, Configuration.getInstance().getPingTargets()), 0, 2, TimeUnit.MINUTES);
+        scheduleStatusCheck();
+    }
+
+    public static void scheduleStatusCheck() {
+        scheduledThreadPoolExecutor.getQueue().clear();
+        List<Credentials> credentialsList = CredentialStore.INSTANCE.getCredentialsList();
+        List<Jid> pingTargetList = CredentialStore.INSTANCE.getPingTargets();
+        for (Credentials credentials : credentialsList) {
+            scheduledThreadPoolExecutor.scheduleAtFixedRate(new ServerStatusChecker(credentials, pingTargetList), 0, 2, TimeUnit.MINUTES);
         }
         scheduledThreadPoolExecutor.scheduleAtFixedRate(new ServerStatusStore.HistoricalDataUpdater(),0,10,TimeUnit.MINUTES);
     }

--- a/src/main/java/im/conversations/status/persistence/CredentialStore.java
+++ b/src/main/java/im/conversations/status/persistence/CredentialStore.java
@@ -3,7 +3,6 @@ package im.conversations.status.persistence;
 import im.conversations.status.Main;
 import im.conversations.status.pojo.Configuration;
 import im.conversations.status.pojo.Credentials;
-import im.conversations.status.xmpp.CredentialsVerifier;
 import org.sql2o.Connection;
 import org.sql2o.Sql2o;
 import rocks.xmpp.addr.Jid;
@@ -35,18 +34,18 @@ public class CredentialStore {
     }
 
     public boolean put(Credentials credentials) {
-        boolean success = CredentialsVerifier.verifyCredentials(credentials);
-        if (success) {
-            synchronized (this.database) {
-                try (Connection connection = this.database.open()) {
-                    final String addCreds = "INSERT into credentials(jid,password) VALUES(:jid,:password)";
-                    connection.createQuery(addCreds).bind(credentials).executeUpdate();
-                }
+        synchronized (this.database) {
+            try (Connection connection = this.database.open()) {
+                final String addCreds = "INSERT into credentials(jid,password) VALUES(:jid,:password)";
+                connection.createQuery(addCreds).bind(credentials).executeUpdate();
+            } catch (Exception ex) {
+                ex.printStackTrace();
+                return false;
             }
             fetchCredentials();
             Main.scheduleStatusCheck();
         }
-        return success;
+        return true;
     }
 
     private void fetchCredentials() {

--- a/src/main/java/im/conversations/status/persistence/CredentialStore.java
+++ b/src/main/java/im/conversations/status/persistence/CredentialStore.java
@@ -36,7 +36,7 @@ public class CredentialStore {
 
     public boolean put(Credentials credentials) {
         boolean success = CredentialsVerifier.verifyCredentials(credentials);
-        if(success) {
+        if (success) {
             synchronized (this.database) {
                 try (Connection connection = this.database.open()) {
                     final String addCreds = "INSERT into credentials(jid,password) VALUES(:jid,:password)";
@@ -57,12 +57,11 @@ public class CredentialStore {
             } catch (Exception ex) {
                 System.out.println("Could not get credentials from database");
             }
-            credentialsList.add(0,Configuration.getInstance().getPrimaryCredentials());
         }
     }
 
     public List<Credentials> getCredentialsList() {
-        if(credentialsList == null) {
+        if (credentialsList == null) {
             fetchCredentials();
         }
         return Collections.unmodifiableList(credentialsList);

--- a/src/main/java/im/conversations/status/persistence/ServerStatusStore.java
+++ b/src/main/java/im/conversations/status/persistence/ServerStatusStore.java
@@ -115,7 +115,7 @@ public class ServerStatusStore {
 
         @Override
         public void run() {
-            final List<Jid> domains = new ArrayList<>(Configuration.getInstance().getDomains());
+            final List<Jid> domains = new ArrayList<>(CredentialStore.INSTANCE.getDomains());
             Collections.sort(domains);
             for (Jid domain : domains) {
                 final HistoricalLoginStatuus statuus = create(domain.getDomain());

--- a/src/main/java/im/conversations/status/pojo/Configuration.java
+++ b/src/main/java/im/conversations/status/pojo/Configuration.java
@@ -9,30 +9,21 @@ import rocks.xmpp.addr.Jid;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class Configuration {
 
     private static File FILE = new File("config.json");
     private static Configuration INSTANCE;
 
-    private List<Credentials> credentials = Collections.emptyList();
     private List<Jid> additionalDomains = Collections.emptyList();
-    private List<Jid> domains = Collections.emptyList();
-    private List<Jid> pingTargets = new ArrayList<>();
     private String ip = "127.0.0.1";
     private int port = 4567;
     private String storagePath = "."+File.separator;
 
     private Configuration() {
 
-    }
-
-    public List<Credentials> getCredentials() {
-        return credentials;
     }
 
     public String getIp() {
@@ -51,12 +42,8 @@ public class Configuration {
         }
     }
 
-    public List<Jid> getDomains() {
-        return domains;
-    }
-
-    public List<Jid> getPingTargets() {
-        return pingTargets;
+    public List<Jid> getAdditionalDomains() {
+        return additionalDomains;
     }
 
     public synchronized static void setFilename(String filename) {
@@ -80,10 +67,6 @@ public class Configuration {
         try {
             System.out.println("Reading configuration from "+FILE.getAbsolutePath());
             final Configuration configuration = gson.fromJson(new FileReader(FILE),Configuration.class);
-            configuration.domains = configuration.credentials.stream().map(c -> Jid.of(c.getJid().getDomain())).collect(Collectors.toList());
-            configuration.pingTargets.addAll(configuration.domains);
-            configuration.pingTargets.addAll(configuration.additionalDomains);
-            Collections.sort(configuration.pingTargets);
             return configuration;
         } catch (FileNotFoundException e) {
             throw new RuntimeException("Configuration file not found");

--- a/src/main/java/im/conversations/status/pojo/Configuration.java
+++ b/src/main/java/im/conversations/status/pojo/Configuration.java
@@ -18,6 +18,7 @@ public class Configuration {
     private static Configuration INSTANCE;
 
     private List<Jid> additionalDomains = Collections.emptyList();
+    private Credentials primaryCredentials;
     private String ip = "127.0.0.1";
     private int port = 4567;
     private String storagePath = "."+File.separator;
@@ -32,6 +33,10 @@ public class Configuration {
 
     public int getPort() {
         return port;
+    }
+
+    public Credentials getPrimaryCredentials() {
+        return primaryCredentials;
     }
 
     public String getStoragePath() {

--- a/src/main/java/im/conversations/status/pojo/Configuration.java
+++ b/src/main/java/im/conversations/status/pojo/Configuration.java
@@ -18,7 +18,7 @@ public class Configuration {
     private static Configuration INSTANCE;
 
     private List<Jid> additionalDomains = Collections.emptyList();
-    private Credentials primaryCredentials;
+    private String primaryDomain;
     private String ip = "127.0.0.1";
     private int port = 4567;
     private String storagePath = "."+File.separator;
@@ -35,10 +35,9 @@ public class Configuration {
         return port;
     }
 
-    public Credentials getPrimaryCredentials() {
-        return primaryCredentials;
+    public String getPrimaryDomain() {
+        return primaryDomain;
     }
-
     public String getStoragePath() {
         if (storagePath.endsWith(File.separator)) {
             return storagePath;

--- a/src/main/java/im/conversations/status/pojo/Credentials.java
+++ b/src/main/java/im/conversations/status/pojo/Credentials.java
@@ -4,16 +4,16 @@ import rocks.xmpp.addr.Jid;
 
 public class Credentials {
 
-    private final Jid jid;
+    private final String jid;
     private final String password;
 
-    private Credentials(String jid, String password) {
-        this.jid = Jid.of(jid);
+    public Credentials(String jid, String password) {
+        this.jid = jid;
         this.password = password;
     }
 
     public Jid getJid() {
-        return jid;
+        return Jid.of(jid);
     }
 
     public String getPassword() {

--- a/src/main/java/im/conversations/status/web/Controller.java
+++ b/src/main/java/im/conversations/status/web/Controller.java
@@ -20,7 +20,8 @@ public class Controller {
             return new ModelAndView(null, "add.ftl");
         }
         final String param = request.params("domain");
-        final String primaryDomain = Configuration.getInstance().getPrimaryCredentials().getJid().getDomain();
+        final String primaryDomain = Configuration.getInstance().getPrimaryDomain() == null ?
+                domains.get(0).getDomain() : Configuration.getInstance().getPrimaryDomain();
         final String domain = param == null ? primaryDomain : Jid.ofDomain(param).getDomain();
         if (param != null && domain.equals(primaryDomain)) {
             response.redirect("/");
@@ -29,10 +30,11 @@ public class Controller {
         ServerStatus serverStatus = ServerStatusStore.INSTANCE.getServerStatus(domain);
         HashMap<String, Object> model = new HashMap<>();
         model.put("domain", domain);
+        model.put("primaryDomain",primaryDomain);
         if (serverStatus != null) {
             model.put("serverStatus", serverStatus);
             model.put("availableDomains", domains);
-        } else if(domains.stream().map(d -> d.getDomain()).anyMatch(d -> d.equals(domain))) {
+        } else if(domains.stream().map(Jid::getDomain).anyMatch(d -> d.equals(domain))) {
             // If domain is present in domain list but it's result is not present in server status
             halt(200,"Running tests on the server. Refresh after some time to see results");
         }
@@ -41,6 +43,9 @@ public class Controller {
 
     public static TemplateViewRoute getHistorical = (request, response) -> {
         HashMap<String, Object> model = new HashMap<>();
+        final String primaryDomain = Configuration.getInstance().getPrimaryDomain() == null ?
+                CredentialStore.INSTANCE.getDomains().get(0).getDomain() : Configuration.getInstance().getPrimaryDomain();
+        model.put("primaryDomain",primaryDomain);
         model.put("serverMap", ServerStatusStore.INSTANCE.getStringHistoricalLoginStatuusMap());
         model.put("durations", HistoricalLoginStatuus.DURATIONS);
         model.put("availableDomains", CredentialStore.INSTANCE.getDomains());

--- a/src/main/java/im/conversations/status/web/Controller.java
+++ b/src/main/java/im/conversations/status/web/Controller.java
@@ -1,5 +1,7 @@
 package im.conversations.status.web;
 
+import im.conversations.status.Main;
+import im.conversations.status.persistence.CredentialStore;
 import im.conversations.status.persistence.ServerStatusStore;
 import im.conversations.status.pojo.*;
 import rocks.xmpp.addr.Jid;
@@ -7,20 +9,19 @@ import spark.ModelAndView;
 import spark.TemplateViewRoute;
 
 import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 
 import static spark.Spark.halt;
 
 public class Controller {
 
     public static TemplateViewRoute getStatus = (request, response) -> {
-        final Configuration configuration = Configuration.getInstance();
-        if (configuration.getDomains().size() == 0) {
-            halt(500, "You have to configure at least on server");
-            return new ModelAndView(null, "redirect.ftl");
+        final List<Jid> domains = CredentialStore.INSTANCE.getDomains();
+        if (domains.size() == 0) {
+            return new ModelAndView(null, "add.ftl");
         }
         final String param = request.params("domain");
-        final String primaryDomain = configuration.getDomains().get(0).getDomain();
+        final String primaryDomain = domains.get(0).getDomain();
         final String domain = param == null ? primaryDomain : Jid.ofDomain(param).getDomain();
         if (param != null && domain.equals(primaryDomain)) {
             response.redirect("/");
@@ -31,7 +32,7 @@ public class Controller {
         model.put("domain", domain);
         if (serverStatus != null) {
             model.put("serverStatus", serverStatus);
-            model.put("availableDomains", configuration.getDomains());
+            model.put("availableDomains", domains);
         }
         return new ModelAndView(model, "status.ftl");
     };
@@ -40,7 +41,7 @@ public class Controller {
         HashMap<String, Object> model = new HashMap<>();
         model.put("serverMap", ServerStatusStore.INSTANCE.getStringHistoricalLoginStatuusMap());
         model.put("durations", HistoricalLoginStatuus.DURATIONS);
-        model.put("availableDomains", Configuration.getInstance().getDomains());
+        model.put("availableDomains", CredentialStore.INSTANCE.getDomains());
         return new ModelAndView(model, "historical.ftl");
     };
 
@@ -50,5 +51,22 @@ public class Controller {
         model.put("pingResults", ServerStatusStore.INSTANCE.getReverseStatusMap(domain));
         model.put("domain",domain);
         return new ModelAndView(model, "reverse.ftl");
+    };
+
+    public static TemplateViewRoute getAdd = (request, response) -> new ModelAndView(null,"add.ftl");
+
+    public static TemplateViewRoute postAdd = (request, response) -> {
+        String jid = request.queryParams("jid");
+        String password = request.queryParams("password");
+        Credentials credentials = new Credentials(jid,password);
+        boolean status = CredentialStore.INSTANCE.put(credentials);
+        if(status) {
+            Main.scheduleStatusCheck();
+            response.redirect("/" + credentials.getJid().getDomain());
+        }
+        else {
+            halt(400,"Could not add server with the provided credentials");
+        }
+        return null;
     };
 }

--- a/src/main/java/im/conversations/status/xmpp/CredentialsVerifier.java
+++ b/src/main/java/im/conversations/status/xmpp/CredentialsVerifier.java
@@ -13,7 +13,13 @@ public class CredentialsVerifier {
         XmppSessionConfiguration xmppSessionConfiguration = XmppSessionConfiguration.builder()
                 .defaultResponseTimeout(Duration.ofSeconds(10))
                 .build();
-        Jid jid = credentials.getJid();
+        Jid jid;
+        // Handles invalid credentials gracefully rather than throwing Internal Server error
+        try {
+            jid = credentials.getJid();
+        } catch (Exception ex) {
+            return false;
+        }
         String password = credentials.getPassword();
         try (XmppClient xmppClient = XmppClient.create(jid.getDomain(), xmppSessionConfiguration)) {
             xmppClient.connect();

--- a/src/main/java/im/conversations/status/xmpp/CredentialsVerifier.java
+++ b/src/main/java/im/conversations/status/xmpp/CredentialsVerifier.java
@@ -1,0 +1,27 @@
+package im.conversations.status.xmpp;
+
+import im.conversations.status.pojo.Credentials;
+import rocks.xmpp.addr.Jid;
+import rocks.xmpp.core.XmppException;
+import rocks.xmpp.core.session.XmppClient;
+import rocks.xmpp.core.session.XmppSessionConfiguration;
+
+import java.time.Duration;
+
+public class CredentialsVerifier {
+    public static boolean verifyCredentials(Credentials credentials) {
+        XmppSessionConfiguration xmppSessionConfiguration = XmppSessionConfiguration.builder()
+                .defaultResponseTimeout(Duration.ofSeconds(10))
+                .build();
+        Jid jid = credentials.getJid();
+        String password = credentials.getPassword();
+        try (XmppClient xmppClient = XmppClient.create(jid.getDomain(), xmppSessionConfiguration)) {
+            xmppClient.connect();
+            xmppClient.login(jid.getLocal(), password);
+        } catch (XmppException e) {
+            e.printStackTrace();
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/resources/spark/template/freemarker/add.ftl
+++ b/src/main/resources/spark/template/freemarker/add.ftl
@@ -1,9 +1,10 @@
 <#ftl output_format="HTML">
 <#import "page.ftl" as page/>
-<@page.page title="Add server for XMPP status checker" historical=false add=true>
+<@page.page title="Add server for XMPP status checker" historical=false>
+<#assign accent= "#3f51b5">
 <style>
     form > * {
-        font-size: 1em;
+        font-size: 0.9em;
     }
     label {
         display: inline-block;
@@ -13,29 +14,30 @@
     }
     input {
         width: 300px;
-        font-size: 0.95em;
+        font-size: 0.9em;
         background: none;
         text-decoration: none;
         outline: none !important;
         border: none;
-        border-bottom: solid 2px #43a047;
+        border-bottom: solid 2px ${accent};
     }
     form > div {
-        margin: 10px;
-        padding: 10px;
+        margin: 5px;
+        padding: 5px;
     }
     #form_button {
-        width: 200px;
-        font-size: 1em;
+        width: 150px;
+        font-size: 0.95em;
         background: none;
-        border: solid 2px #43a047;
+        border: solid 2px ${accent};
         cursor: pointer;
         text-align: center;
-        margin-left: 50px;
-        padding: 10px;
+        margin-left: 100px;
+        margin-top: 10px;
+        padding: 6px;
     }
     #form_button:hover {
-      background: #43a047;
+      background: ${accent};
       color: #F2F3EB;
       -webkit-transition: all 0.3s;
       -transition: all 0.3s;

--- a/src/main/resources/spark/template/freemarker/add.ftl
+++ b/src/main/resources/spark/template/freemarker/add.ftl
@@ -1,6 +1,6 @@
 <#ftl output_format="HTML">
 <#import "page.ftl" as page/>
-<@page.page title="Add server for XMPP status checker" historical=false>
+<@page.page title="Add server for XMPP status checker" historical=false add=true>
 <h1>Add credentials for your server</h1>
 <form action="/add/" method="post">
     JID:<br>

--- a/src/main/resources/spark/template/freemarker/add.ftl
+++ b/src/main/resources/spark/template/freemarker/add.ftl
@@ -1,12 +1,61 @@
 <#ftl output_format="HTML">
 <#import "page.ftl" as page/>
 <@page.page title="Add server for XMPP status checker" historical=false add=true>
+<style>
+    form > * {
+        font-size: 1em;
+    }
+    label {
+        display: inline-block;
+        width: 80px;
+        margin-right: 10px;
+        text-align: right;
+    }
+    input {
+        width: 300px;
+        font-size: 0.95em;
+        background: none;
+        text-decoration: none;
+        outline: none !important;
+        border: none;
+        border-bottom: solid 2px #43a047;
+    }
+    form > div {
+        margin: 10px;
+        padding: 10px;
+    }
+    #form_button {
+        width: 200px;
+        font-size: 1em;
+        background: none;
+        border: solid 2px #43a047;
+        cursor: pointer;
+        text-align: center;
+        margin-left: 50px;
+        padding: 10px;
+    }
+    #form_button:hover {
+      background: #43a047;
+      color: #F2F3EB;
+      -webkit-transition: all 0.3s;
+      -transition: all 0.3s;
+      -ms-transition: all 0.3s;
+      -o-transition: all 0.3s;
+      transition: all 0.3s;
+    }
+</style>
 <h1>Add credentials for your server</h1>
 <form action="/add/" method="post">
-    JID:<br>
-    <input type="text" name="jid"/><br>
-    Password:<br>
-    <input type="password" name="password"/><br>
-    <input type="submit" value="Submit"/>
+    <div>
+        <label for="jid">JID</label>
+        <input type="text" name="jid"/>
+    </div>
+    <div>
+        <label for="password">Password</label>
+        <input type="password" name="password"/>
+    </div>
+    <div>
+        <input type="submit" id="form_button" value="Submit"/>
+    </div>
 </form>
 </@page.page>

--- a/src/main/resources/spark/template/freemarker/add.ftl
+++ b/src/main/resources/spark/template/freemarker/add.ftl
@@ -1,0 +1,12 @@
+<#ftl output_format="HTML">
+<#import "page.ftl" as page/>
+<@page.page title="Add server for XMPP status checker" historical=false>
+<h1>Add credentials for your server</h1>
+<form action="/add/" method="post">
+    JID:<br>
+    <input type="text" name="jid"/><br>
+    Password:<br>
+    <input type="password" name="password"/><br>
+    <input type="submit" value="Submit"/>
+</form>
+</@page.page>

--- a/src/main/resources/spark/template/freemarker/historical.ftl
+++ b/src/main/resources/spark/template/freemarker/historical.ftl
@@ -1,6 +1,6 @@
 <#ftl output_format="HTML">
 <#import "page.ftl" as page/>
-<@page.page title="Historical uptime data" historical=true>
+<@page.page title="Historical uptime data" historical=true add=false>
 <h1>Historical uptime data</h1>
 <#if serverMap?size == 0>
     <p class="info">Calculating historical data</p>

--- a/src/main/resources/spark/template/freemarker/historical.ftl
+++ b/src/main/resources/spark/template/freemarker/historical.ftl
@@ -1,6 +1,6 @@
 <#ftl output_format="HTML">
 <#import "page.ftl" as page/>
-<@page.page title="Historical uptime data" historical=true add=false>
+<@page.page title="Historical uptime data" historical=true>
 <h1>Historical uptime data</h1>
 <#if serverMap?size == 0>
     <p class="info">Calculating historical data</p>

--- a/src/main/resources/spark/template/freemarker/historical.ftl
+++ b/src/main/resources/spark/template/freemarker/historical.ftl
@@ -16,7 +16,7 @@
     </thead>
     <#list serverMap as server, historicalData>
         <tr>
-            <td><a href="/<#if availableDomains?seq_index_of(server) != 0>${server}/</#if>">${server}</a></td>
+            <td><a href="/<#if server != primaryDomain>${server}/</#if>">${server}</a></td>
             <#list durations as duration>
                 <#if historicalData.isAvailableForDuration(duration)>
                     <#assign availability=historicalData.getForDuration(duration)>

--- a/src/main/resources/spark/template/freemarker/live.ftl
+++ b/src/main/resources/spark/template/freemarker/live.ftl
@@ -1,0 +1,49 @@
+<#ftl output_format="HTML">
+<#import "page.ftl" as page/>
+<@page.page title="Checking status of ${domain}" historical=false add=false>
+<script>
+    xhttp = new XMLHttpRequest();
+    xhttp.onreadystatechange = function() {
+        if (this.readyState == 4) {
+            if(this.responseText == "AVAILABLE") {
+                var redirectUrl = window.location.protocol + "//" + location.hostname + ":" + location.port + "/${domain}";
+                window.location.replace(redirectUrl);
+            } else if(this.status != 404) {
+                setTimeout(function() {
+                    this.open("GET", "/availability/${domain}", true);
+                    this.send();
+                }.bind(this),500);
+            }
+        }
+    };
+    xhttp.open("GET", "/availability/${domain}", true);
+    xhttp.send();
+</script>
+<style>
+    .status > *,.status {
+        font-size: 1.2em;
+        display: inline;
+        vertical-align: middle;
+        line-height: 116px;
+        margin: 10px;
+    }
+.loader {
+    border: 16px solid #f3f3f3; /* Light grey */
+    border-top: 16px solid #43a047; /* Blue */
+    border-radius: 50%;
+    display: inline-block;
+    width: 60px;
+    height: 60px;
+    animation: spin 2s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+</style>
+<div class = "status">
+    <div class = "loader"></div>
+    <div>Checking current status for ${domain}</div>
+</div>
+</@page.page>

--- a/src/main/resources/spark/template/freemarker/live.ftl
+++ b/src/main/resources/spark/template/freemarker/live.ftl
@@ -1,6 +1,6 @@
 <#ftl output_format="HTML">
 <#import "page.ftl" as page/>
-<@page.page title="Checking status of ${domain}" historical=false add=false>
+<@page.page title="Checking status of ${domain}" historical=false>
 <script>
     xhttp = new XMLHttpRequest();
     xhttp.onreadystatechange = function() {

--- a/src/main/resources/spark/template/freemarker/page.ftl
+++ b/src/main/resources/spark/template/freemarker/page.ftl
@@ -1,4 +1,4 @@
-<#macro page title="" historical=false add=false>
+<#macro page title="" historical=false>
 <!DOCTYPE html>
 <html>
 <head>
@@ -75,7 +75,7 @@
 </head>
 <body>
     <#nested />
-<p class="small">Copyright 2017 <a href="https://gultsch.de">Daniel Gultsch</a> <#if !historical>&middot; <a href="/historical/">Historical data</a></#if><#if !add> &middot; <a href="/add">Add your server</a></#if> &middot; <a href="https://github.com/iNPUTmice/ServerStatus">Source code</a></p>
+<p class="small">Copyright 2017 <a href="https://gultsch.de">Daniel Gultsch</a> <#if !historical>&middot; <a href="/historical/">Historical data</a></#if> &middot; <a href="https://github.com/iNPUTmice/ServerStatus">Source code</a></p>
 </body>
 </html>
 </#macro>

--- a/src/main/resources/spark/template/freemarker/page.ftl
+++ b/src/main/resources/spark/template/freemarker/page.ftl
@@ -75,7 +75,7 @@
 </head>
 <body>
     <#nested />
-<p class="small">Copyright 2017 <a href="https://gultsch.de">Daniel Gultsch</a> <#if !historical>&middot; <a href="/historical/">Historical data</a> </#if>&middot; <a href="https://github.com/iNPUTmice/ServerStatus">Source code</a></p>
+<p class="small">Copyright 2017 <a href="https://gultsch.de">Daniel Gultsch</a> <#if !historical>&middot; <a href="/historical/">Historical data</a> <a href="/add">Add your server to list</a> </#if>&middot; <a href="https://github.com/iNPUTmice/ServerStatus">Source code</a></p>
 </body>
 </html>
 </#macro>

--- a/src/main/resources/spark/template/freemarker/page.ftl
+++ b/src/main/resources/spark/template/freemarker/page.ftl
@@ -1,4 +1,4 @@
-<#macro page title="" historical=false>
+<#macro page title="" historical=false add=false>
 <!DOCTYPE html>
 <html>
 <head>
@@ -75,7 +75,7 @@
 </head>
 <body>
     <#nested />
-<p class="small">Copyright 2017 <a href="https://gultsch.de">Daniel Gultsch</a> <#if !historical>&middot; <a href="/historical/">Historical data</a> <a href="/add">Add your server to list</a> </#if>&middot; <a href="https://github.com/iNPUTmice/ServerStatus">Source code</a></p>
+<p class="small">Copyright 2017 <a href="https://gultsch.de">Daniel Gultsch</a> <#if !historical>&middot; <a href="/historical/">Historical data</a></#if><#if !add> &middot; <a href="/add">Add your server</a></#if> &middot; <a href="https://github.com/iNPUTmice/ServerStatus">Source code</a></p>
 </body>
 </html>
 </#macro>

--- a/src/main/resources/spark/template/freemarker/reverse.ftl
+++ b/src/main/resources/spark/template/freemarker/reverse.ftl
@@ -1,7 +1,7 @@
 <#ftl output_format="HTML">
 <#import "page.ftl" as page/>
 <#assign title="Reverse reachability for ${domain}">
-<@page.page title=$title historical=false add=false>
+<@page.page title=$title historical=false>
 <h1>${title}</h1>
 <table class="rightbound">
     <#list pingResults as result>

--- a/src/main/resources/spark/template/freemarker/reverse.ftl
+++ b/src/main/resources/spark/template/freemarker/reverse.ftl
@@ -1,7 +1,7 @@
 <#ftl output_format="HTML">
 <#import "page.ftl" as page/>
 <#assign title="Reverse reachability for ${domain}">
-<@page.page title=$title historical=false>
+<@page.page title=$title historical=false add=false>
 <h1>${title}</h1>
 <table class="rightbound">
     <#list pingResults as result>

--- a/src/main/resources/spark/template/freemarker/status.ftl
+++ b/src/main/resources/spark/template/freemarker/status.ftl
@@ -13,7 +13,7 @@
             <tr>
                 <td>
                 <#if availableDomains?seq_contains(result.getServer())>
-                    <a href="/<#if availableDomains?seq_index_of(result.getServer()) != 0>${result.getServer()}/</#if>">${result.getServer()}</a>
+                    <a href="/<#if result.getServer() != primaryDomain>${result.getServer()}/</#if>">${result.getServer()}</a>
                 <#elseif linkReverse>
                     <a href="/reverse/${result.getServer()}">${result.getServer()}</a> <sup><small>R</small></sup>
                 <#else>

--- a/src/main/resources/spark/template/freemarker/status.ftl
+++ b/src/main/resources/spark/template/freemarker/status.ftl
@@ -1,6 +1,6 @@
 <#ftl output_format="HTML">
 <#import "page.ftl" as page/>
-<@page.page title="XMPP Server Status for ${domain}" historical=false add=false>
+<@page.page title="XMPP Server Status for ${domain}" historical=false>
 <#if serverStatus??>
     <#assign isLoggedIn = serverStatus.isLoggedIn()>
     <#assign pingResults = serverStatus.getPingResults()>

--- a/src/main/resources/spark/template/freemarker/status.ftl
+++ b/src/main/resources/spark/template/freemarker/status.ftl
@@ -1,6 +1,6 @@
 <#ftl output_format="HTML">
 <#import "page.ftl" as page/>
-<@page.page title="XMPP Server Status for ${domain}" historical=false>
+<@page.page title="XMPP Server Status for ${domain}" historical=false add=false>
 <#if serverStatus??>
     <#assign isLoggedIn = serverStatus.isLoggedIn()>
     <#assign pingResults = serverStatus.getPingResults()>


### PR DESCRIPTION
Users can add their credentials from the frontend by going to /add or by clicking the link in the footer.
The credentials are verified and added to the database and the tests are rescheduled accordingly.

In config.json, instead of having an array of credentials, the user has to populate the credentials in the database from the UI. A new attribute primaryDomain has been added to the configuration. 